### PR TITLE
Added Parameters which get overwritten by setting minimum and maximum angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ This ROS Driver is for Autonics LSC Series
 * ip_change(default : false, type : bool) - Value to enable ip_change
 * prev_addr(default : , type : string) - Ip address of device
 * new_addr(default : , type : string) - Ip address to change
+* rssi_activate(default : true, type : bool) - RSSI data transmission activation ( true : Activated, false : Inactivated )
+* scan_interval(default : 1, type : int) - Scan data cycle ( 1 to 60000 ) x 67ms
+* fieldset_output_activate(default : true, type : bool) - Field set output activation ( true : Activated, false : Inactivated )
 
 
 ### 3. Installation

--- a/include/laser.h
+++ b/include/laser.h
@@ -108,6 +108,9 @@ private:
         INFO_CHANGE,// change cmd send
         GET_RESP// recv ack
     };
+
+    uint16_t scan_interval;
+    uint8_t fieldset_output_activate, rssi_activate;
 };
 
 #endif

--- a/launch/lsc_c25_launch.launch
+++ b/launch/lsc_c25_launch.launch
@@ -17,6 +17,10 @@
         <param name="angle_min" type="double" value="-45.0"/>
         <param name="angle_max" type="double" value="225.0"/>
         <param name="angle_offset" type="double" value="0.0"/>
+
+        <param name="rssi_activate" type="bool" value="true"/>
+        <param name="scan_interval" type="int" value="1"/>
+        <param name="fieldset_output_activate" type="bool" value="true"/>
     </node>
 
     <arg name="model" default="$(find lsc_ros_driver)/urdf/lsc_ros_driver.urdf.xacro"/>

--- a/src/laser.cpp
+++ b/src/laser.cpp
@@ -342,9 +342,9 @@ void AutoLaser::setScanAngle()
     sprintf(&buff[5], ",sWC,LSScanDataConfig,%X,%X,%X,%X,%X\x03",\
     (int) std::round(((scan_msg->angle_min * RAD2DEG) - angle_offset_) * 10000),\
     (int) std::round(((scan_msg->angle_max * RAD2DEG) - angle_offset_) * 10000),\
-    lsc.scan_data_config.rssi_activate,\
-    lsc.scan_data_config.scan_interval,\
-    lsc.scan_data_config.fieldset_output_activate);
+    rssi_activate,\
+    scan_interval,\
+    fieldset_output_activate);
 
     int length = strlen(buff);
 
@@ -707,6 +707,10 @@ int AutoLaser::laserInit(void)
     std::string frame_id = "laser", port = "8000", password = "0000";
     double range_min = 0.05, range_max = 25, angle_min = -45, angle_max = 225, angle_offset = 0;
     uint16_t port_num = 0, recnt_cnt = 0;
+
+    bool fieldset_output_activate_param = 1, rssi_activate_param = 1;
+    int scan_interval_param = 1;
+    
     bool ip_change = false;
     ip_addr = "192.168.0.1";
     topic_name = "scan";
@@ -728,6 +732,41 @@ int AutoLaser::laserInit(void)
     priv_nh.getParam("angle_min", angle_min);
     priv_nh.getParam("angle_max", angle_max);
     priv_nh.getParam("angle_offset", angle_offset);
+
+    scan_interval = 1;
+    fieldset_output_activate = 1;
+    rssi_activate = 1;
+
+    priv_nh.getParam("scan_interval", scan_interval_param);
+    priv_nh.getParam("fieldset_output_activate", fieldset_output_activate_param);
+    priv_nh.getParam("rssi_activate", rssi_activate_param);
+
+    if((scan_interval_param > 0) && (scan_interval_param <= 60000))
+    {
+        scan_interval = (uint16_t)scan_interval_param;
+    }
+    else
+    {
+        scan_interval = 1;
+    }
+
+    if(fieldset_output_activate_param)
+    {
+        fieldset_output_activate = 1;
+    }
+    else
+    {
+        fieldset_output_activate = 0;
+    }
+
+    if(rssi_activate_param)
+    {
+        rssi_activate = 1;
+    }
+    else
+    {
+        rssi_activate = 0;
+    }
     
     scan_msg->header.frame_id = frame_id;
     scan_msg->range_min = range_min;


### PR DESCRIPTION
The sWC LSScanDataConfig ( write ) communication protocol command of LSC lidar is used to set minimum and maximum angles. This randomly overwrites RSSI data transmission activation, Field set output activation and Scan data cycle. Here changes are made to read the parameters such that the above parameters are not randomly overwritten.